### PR TITLE
Bump to Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
   "require": {
     "php": ">=7",
     "composer/installers": "~1.0",
-    "illuminate/view": "~5.5",
-    "illuminate/config": "~5.5"
+    "illuminate/view": "~5.4",
+    "illuminate/config": "~5.4"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "~3.0"

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
   "require": {
     "php": ">=7",
     "composer/installers": "~1.0",
-    "illuminate/view": "~5.4",
-    "illuminate/config": "~5.4"
+    "illuminate/view": "~5.5",
+    "illuminate/config": "~5.5"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "~3.0"


### PR DESCRIPTION
I already extolled the benefits of bumping to 5.5 in the [Installer Pull Request](https://github.com/roots/sage-installer/pull/8). Will keep it short.

Of particular interest to Sage-Lib (mostly for dev purposes, but who knows)
- Auto-registration of Console commands 
- API resources / transformations
- Renderable Mailables and Exceptions. Exceptions are also 
- Simpler custom validation rules
- Convenient Blade shortcuts!!!
- and more.