### PR TITLE
Fix late static bindings

### DIFF
--- a/Config.php
+++ b/Config.php
@@ -4,5 +4,5 @@ namespace Roots\Sage;
 
 class Config extends \Illuminate\Config\Repository
 {
-    	protected static $instance;
+    protected static $instance;
 }

--- a/Config.php
+++ b/Config.php
@@ -4,4 +4,5 @@ namespace Roots\Sage;
 
 class Config extends \Illuminate\Config\Repository
 {
+    	protected static $instance;
 }


### PR DESCRIPTION
We use `Illuminate\Container\Container` and it lives outside of Roots code.

Without this PR, we get:

`
Fatal error: Uncaught TypeError: Argument 1 passed to Foo\{closure}() must be an instance of Roots\Sage\Container, instance of Illuminate\Container\Container given, called in /srv/www/example.com/current/vendor/illuminate/container/Container.php on line 726 and defined in /srv/www/example.com/current/web/app/themes/foo/app/setup.php on line 113
`

(Code from here: https://github.com/roots/sage/blob/master/app/setup.php#L113 )

The reason this happens is that there can only be one global instance of `Illuminate\Container\Container`. If `\Roots\Sage\Container` is indeed supposed to be different than `Illuminate\Container\Container` then it needs to override `$instance` to fix late static bindings.

@see http://php.net/manual/en/language.oop5.late-static-bindings.php

Thank you for your consideration.